### PR TITLE
chore(ci): fix workflows to run on `pull_request` instead of `push`

### DIFF
--- a/.github/workflows/audit-check.yml
+++ b/.github/workflows/audit-check.yml
@@ -2,6 +2,9 @@ name: Security audit
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
This way it will run in PRs from forks
